### PR TITLE
Rawgit is shutting down, replace it with jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ npm install between.js
 ## Or fetch from CDN
 
 ```
-<script src="https://rawgit.com/sasha240100/between.js/master/build/between.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/between.js/build/between.js"></script>
 ```
 
 # Basic usage


### PR DESCRIPTION
I replaced the RawGit link in the readme with a [jsDelivr CDN link](https://www.jsdelivr.com/), since RawGit is going to shut down soon and jsDelivr is a recommended alternative. 